### PR TITLE
Use Maven image supporting Java 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.9.1-eclipse-temurin-8
+FROM maven:3.9.1-eclipse-temurin-17
 WORKDIR /project
 
 COPY pom.xml /project/pom.xml


### PR DESCRIPTION
Change maven image used to a version supporting Java 17 to solve build fails for using unsupported Java versions.