### PR TITLE
Docker fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY analyzer/pom.xml /project/analyzer/pom.xml
 RUN mvn dependency:copy-dependencies
 
 COPY analyzer/src /project/analyzer/src
+COPY config.yml /project/config.yml
 RUN mvn package
 
 ENTRYPOINT ["java", "-jar", "/project/analyzer/target/analyzer-1.0-SNAPSHOT.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ COPY analyzer/pom.xml /project/analyzer/pom.xml
 RUN mvn dependency:copy-dependencies
 
 COPY analyzer/src /project/analyzer/src
+# Make sure to have the local config in the current directory
+COPY config.yml /project/config.yml
 RUN mvn package
 
 ENTRYPOINT ["java", "-jar", "/project/analyzer/target/analyzer-1.0-SNAPSHOT.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ COPY analyzer/pom.xml /project/analyzer/pom.xml
 RUN mvn dependency:copy-dependencies
 
 COPY analyzer/src /project/analyzer/src
-COPY config.yml /project/config.yml
 RUN mvn package
 
 ENTRYPOINT ["java", "-jar", "/project/analyzer/target/analyzer-1.0-SNAPSHOT.jar"]

--- a/analyzer/src/main/resources/config.yml
+++ b/analyzer/src/main/resources/config.yml
@@ -15,7 +15,7 @@ extractors:
 threads: 12
 
 database:
-  hostname: db
+  hostname: localhost
   port: 5432
   name: postgres
   username: postgres

--- a/analyzer/src/main/resources/config.yml
+++ b/analyzer/src/main/resources/config.yml
@@ -15,7 +15,7 @@ extractors:
 threads: 12
 
 database:
-  hostname: localhost
+  hostname: db
   port: 5432
   name: postgres
   username: postgres

--- a/analyzer/src/main/resources/config.yml
+++ b/analyzer/src/main/resources/config.yml
@@ -23,6 +23,7 @@ database:
 
 indexfile: ~
 
+# This should point to the location at which the host's m2 folder was mounted in the container
 m2-dir: ~
 
 seed: 69420

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,10 @@ services:
       dockerfile: Dockerfile
     depends_on:
       - db
-    environment:
-      DB_HOST: db
-      DB_USER: postgres
-      DB_NAME: postgres
-      DB_PASS: SuperSekretPassword
+    volumes:
+      - type: bind
+        source: $SOURCE_M2 # set this in '.env' in the same directory as docker-compose.yml
+        target: /root/.m2
   db:
     image: "postgres:15.2"
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    depends_on:
+      - db
     environment:
       DB_HOST: db
       DB_USER: postgres


### PR DESCRIPTION
 - Fixed application not connecting to db in docker
 - Updated dockerfile to copy and use the local config.yml
 - Added configurable bind mount to bind the .m2 folder in the host to /root/.m2 inside the container

Note: 
- I changed the default config.yml such that the default host of the database is 'db'. If you want to run the program outside Docker, you need to change the host in your config.yml to 'localhost'
- docker-compose.yml cannot use config.yml variables, so you have to create a .env when building the containers. The 'm2-dir' variable inside config.yml should point to the bind mount location inside the container (not the host)