### PR TITLE
Builder fixes

### DIFF
--- a/pyscripts/vc/database.py
+++ b/pyscripts/vc/database.py
@@ -321,11 +321,15 @@ WHERE LOWER(tag_name) IN (
         query = f"""
         SELECT t.groupid, t.artifactid, t.version, tag_name, release_tag_name,
                t.url, java_version_manifest_2,
-               java_version_manifest_3, java_version_class_major, output_timestamp_prop
+               java_version_manifest_3, compiler_version_source, output_timestamp_prop,
+               lastmodified
         FROM {self.TAGS_TABLE} AS t
         JOIN {self.PKG_TABLE} p on t.groupid = p.groupid
             AND t.artifactid = p.artifactid
             AND t.version = p.version
+        JOIN {self.PKG_LIST_TABLE} pl on t.groupid = pl.groupid
+            AND t.artifactid = pl.artifactid
+            AND t.version = pl.version
         WHERE output_timestamp_prop IS NOT NULL
         AND 
         t.url IS NOT NULL

--- a/pyscripts/vc/database.py
+++ b/pyscripts/vc/database.py
@@ -322,7 +322,7 @@ WHERE LOWER(tag_name) IN (
         SELECT t.groupid, t.artifactid, t.version, tag_name, release_tag_name,
                t.url, java_version_manifest_2,
                java_version_manifest_3, compiler_version_source, output_timestamp_prop,
-               lastmodified
+               lastmodified, line_ending_lf, line_ending_crlf, line_ending_inconsistent_in_file
         FROM {self.TAGS_TABLE} AS t
         JOIN {self.PKG_TABLE} p on t.groupid = p.groupid
             AND t.artifactid = p.artifactid
@@ -374,7 +374,7 @@ WHERE LOWER(tag_name) IN (
         from_existing, build_success, stdout, stderr, ok_files, ko_files, command)
         VALUES (%s{12*",%s"}) ON CONFLICT DO NOTHING; 
         """
-        self.execute(
+        self.cur.execute(
             query,
             [
                 bs.groupid,

--- a/pyscripts/vc/main.py
+++ b/pyscripts/vc/main.py
@@ -51,7 +51,7 @@ def main():
         log.info("Running Builder...")
         builder = BuildPackages(db, config)
         builder.clone_rep_central()
-        builder.build_and_compare()
+        builder.build_all()
 
     # Don't forget to note down the last commit of the cloned Reproducible Central repo
 

--- a/pyscripts/vc/utils.py
+++ b/pyscripts/vc/utils.py
@@ -1,5 +1,6 @@
 import re
 from giturlparse import parse
+from psycopg2.extras import DictRow
 
 
 # https://maven.apache.org/scm/scm-url-format.html
@@ -57,3 +58,18 @@ def parse_plus(url: str):
         return parse(url + ".git")
     https_url = re.sub(r"http:", "https:", url)
     return parse(https_url)
+
+
+def get_field(record: DictRow, field_name: str, mandatory: bool = False):
+    """Gets database record value in a given field. Can return None if
+    mandatory = False and value in field is null.
+
+    Throws:
+    ValueError if value in field is null,
+    KeyError if field_name not present in record
+    """
+    val = record[field_name]
+    if mandatory and not val:
+        raise ValueError(f"{field_name} is null")
+    else:
+        return val


### PR DESCRIPTION
- [x] Also use the Build-Jdk entry in Manifest.MF to determine the JDK compiler version. If not available, build with all LTS versions up to the latest version at the publish date of the package.
- [x] If newline has been found by the analyzer, only build with that newline character

Address this later:
- Also use compiler_version_release field to determine jdk build version 
#94 
- Change command to only include relevant sub-module for multi-module projects
#95